### PR TITLE
Dockerisation pour déploiement sur serveur

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git/
+.images/
+.resources/
+
+.dockerignore
+.gitignore
+config.example.json
+config.json
+data.json
+docker-compose.yml
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.10-alpine
 
 WORKDIR /pvc-bot
 COPY . .
-RUN pip -r requirements.txt
+RUN pip install -r requirements.txt
 
-ENTRYPOINT py main.py
+ENTRYPOINT python3 main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-alpine
+
+WORKDIR /pvc-bot
+COPY . .
+RUN pip -r requirements.txt
+
+ENTRYPOINT py main.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+image: pvc-bot
+volumes:
+  - type: bind
+    source: ./config.json
+    target: ./config.json
+    read_only: true
+  - type: bind
+    source: ./data.json
+    target: ./data.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.7"
 services:
   pvc:
     image: pvc-bot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
-version: "3.9"
-image: pvc-bot
-volumes:
-  - type: bind
-    source: ./config.json
-    target: ./config.json
-    read_only: true
-  - type: bind
-    source: ./data.json
-    target: ./data.json
+version: "3.3"
+services:
+  pvc:
+    image: pvc-bot
+    volumes:
+     - type: bind
+       source: ./config.json
+       target: /pvc-bot/config.json
+       read_only: true
+     - type: bind
+       source: ./data.json
+       target: /pvc-bot/data.json


### PR DESCRIPTION
Pour déployer facilement et de manière pérenne le bot sur un VPS quelconque sans se soucier de son environnement, il fallait dockeriser PVC.

Cela est désormais fait, le bot est déployé en production en utilisant le code de cette branche, ainsi je propose directement de merge cela sur master, sans passer par devel auparavant.